### PR TITLE
fix(table charts):  Associate search input with its label

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -157,8 +157,9 @@ function SortIcon<D extends object>({ column }: { column: ColumnInstance<D> }) {
 function SearchInput({ count, value, onChange }: SearchInputProps) {
   return (
     <span className="dt-global-filter">
-      {t('Search')}{' '}
+      <span id="tc-search-label">{t('Search')} </span>
       <input
+        aria-labelledby="tc-search-label"
         className="form-control input-sm"
         placeholder={tn('search.num_records', count)}
         value={value}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Previously, screen readers could not clearly read the search input's label because the span inner text was not associated with the input. Changing span to label fixes screen reader accessibility, but impacts component styling, so I chose to add an inner span around the text and connect it to the input using aria-labelledby.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Add a table chart to dashboard. Navigate to search box using a screen reader.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: [26175](https://github.com/orgs/Superset-Community-Partners/projects/1?pane=issue&itemId=47378090)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
